### PR TITLE
add more exports so users can change db configs

### DIFF
--- a/ts/src/db_connection.ts
+++ b/ts/src/db_connection.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { Connection, ConnectionOptions, createConnection } from 'typeorm';
 
-import { defaultConnectionOptions } from './default_ormconfig';
+import { defaultOrmConfig } from './default_ormconfig';
 
 let connectionIfExists: Connection | undefined;
 
@@ -30,6 +30,6 @@ export async function initDBConnectionAsync(options?: ConnectionOptions): Promis
     if (!_.isUndefined(connectionIfExists)) {
         throw new Error('DB connection already exists');
     }
-    const connOptions = options === undefined ? defaultConnectionOptions : options;
+    const connOptions = options === undefined ? defaultOrmConfig : options;
     connectionIfExists = await createConnection(connOptions);
 }

--- a/ts/src/default_ormconfig.ts
+++ b/ts/src/default_ormconfig.ts
@@ -4,7 +4,7 @@ import { OrderEntity } from './entities/order_entity';
 import { TakerAssetFillAmountEntity } from './entities/taker_asset_fill_amount_entity';
 import { TransactionEntity } from './entities/transaction_entity';
 
-export const defaultConnectionOptions: ConnectionOptions = {
+export const defaultOrmConfig: ConnectionOptions = {
         type: 'sqlite',
         database: 'database.sqlite',
         synchronize: true,

--- a/ts/src/handlers.ts
+++ b/ts/src/handlers.ts
@@ -38,7 +38,7 @@ enum ExchangeMethods {
     MarketSellOrdersNoThrow = 'marketSellOrdersNoThrow',
     MarketBuyOrders = 'marketBuyOrders',
     MarketBuyOrdersNoThrow = 'marketBuyOrdersNoThrow',
-    MatchOrders = 'matchOrders',
+
     CancelOrder = 'cancelOrder',
     BatchCancelOrders = 'batchCancelOrders',
 }

--- a/ts/src/handlers.ts
+++ b/ts/src/handlers.ts
@@ -38,7 +38,7 @@ enum ExchangeMethods {
     MarketSellOrdersNoThrow = 'marketSellOrdersNoThrow',
     MarketBuyOrders = 'marketBuyOrders',
     MarketBuyOrdersNoThrow = 'marketBuyOrdersNoThrow',
-
+    MatchOrders = 'matchOrders',
     CancelOrder = 'cancelOrder',
     BatchCancelOrders = 'batchCancelOrders',
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,1 +1,5 @@
 export { getAppAsync } from './app';
+export { OrderEntity } from './entities/order_entity';
+export { TakerAssetFillAmountEntity } from './entities/taker_asset_fill_amount_entity';
+export { TransactionEntity } from './entities/transaction_entity';
+export { defaultOrmConfig } from './default_ormconfig';


### PR DESCRIPTION
Running into compilation errors when trying to specify different db configs. 

This PR exports more members so they become known types when compiling the importing code. 

Example:
```
import { defaultConnectionOptions } from '@0x/coordinator-server/ts/src/default_ormconfig';

const alternateDbConfigs: ConnectionOptions = {
    ...defaultConnectionOptions,
    type: 'sqlite',
    database: 'database.sqlite_copy',
};

anotherCoordinatorServerApp = await getAppAsync(
    {
        [config.networkId]: provider,
    },
    coordinatorServerConfigs,
    alternateDbConfigs,
);
```

Build errors:
<img width="1420" alt="Screen Shot 2019-04-26 at 8 47 17 PM" src="https://user-images.githubusercontent.com/8582774/56844403-8b06ae80-6864-11e9-8502-1925f0160817.png">


