### PR TITLE
Allow Contract addresses to be provided in Config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0x/coordinator-server",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "0x Coordinator reference server implementation",
     "repository": "git@github.com:0xProject/0x-coordinator-server.git",
     "license": "Apache-2.0",

--- a/ts/src/handlers.ts
+++ b/ts/src/handlers.ts
@@ -210,8 +210,12 @@ export class Handlers {
         this._networkIdToContractWrappers = {};
         _.each(networkIdToProvider, (provider: Web3ProviderEngine, networkIdStr: string) => {
             const networkId = _.parseInt(networkIdStr);
+            const contractAddresses = configs.NETWORK_ID_TO_CONTRACT_ADDRESSES
+                ? configs.NETWORK_ID_TO_CONTRACT_ADDRESSES[networkId]
+                : undefined;
             const contractWrappers = new ContractWrappers(provider, {
                 networkId,
+                contractAddresses,
             });
             this._networkIdToContractWrappers[networkId] = contractWrappers;
         });
@@ -580,10 +584,10 @@ export class Handlers {
         networkId: number,
         approvalExpirationTimeSeconds: number,
     ): Promise<RequestTransactionResponse> {
-        const contractAddresses = getContractAddressesForNetworkOrThrow(networkId);
+        const contractWrappers = this._networkIdToContractWrappers[networkId];
         const typedData = eip712Utils.createCoordinatorApprovalTypedData(
             signedTransaction,
-            contractAddresses.coordinator,
+            contractWrappers.coordinator.address,
             txOrigin,
             new BigNumber(approvalExpirationTimeSeconds),
         );

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -1,4 +1,4 @@
-import { ContractWrappers } from '@0x/contract-wrappers';
+import { ContractAddresses, ContractWrappers } from '@0x/contract-wrappers';
 import { Web3ProviderEngine } from '@0x/subproviders';
 import { Order, ZeroExTransaction } from '@0x/types';
 import { BigNumber } from '@0x/utils';
@@ -7,6 +7,7 @@ import * as WebSocket from 'websocket';
 export interface Configs {
     HTTP_PORT: number;
     NETWORK_ID_TO_SETTINGS: NetworkIdToNetworkSpecificSettings;
+    NETWORK_ID_TO_CONTRACT_ADDRESSES?: NetworkIdToContractAddresses;
     SELECTIVE_DELAY_MS: number;
     EXPIRATION_DURATION_SECONDS: number;
 }
@@ -86,6 +87,9 @@ export interface NetworkSpecificSettings {
     RPC_URL: string;
 }
 
+export interface NetworkIdToContractAddresses {
+    [networkId: number]: ContractAddresses;
+}
 export interface NetworkIdToNetworkSpecificSettings {
     [networkId: number]: NetworkSpecificSettings;
 }


### PR DESCRIPTION
Allows contract addresses to be provided when instantiating a `Handler`. This assists in testing and migration changes when the Coordinator address can change if new contracts are added to Migrations. There is a bit of a cyclic dependency between `0x-monorepo->contract-addresses` and `0x-monorepo->0x-coordinator-server->contract-addresses`. 

See [here](https://github.com/0xProject/0x-monorepo/pull/2021/files#diff-bdaf823154cef8fcd5c2db48d3aa7668) for updated usage in our tests.

0xProject/0x-monorepo#2021