### PR TITLE
Use whitelist of approved CFL takers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ To develop ontop of `0x-coordinator-server`, follow the following instructions:
     yarn
     ```
 
-5. Edit the `src/production_configs.ts` file to work with your relayer:
+5. Edit the `src/production_configs.ts` file, or configure the corresponding environment variables in your runtime environment, to work with your relayer:
 
 -   `FEE_RECIPIENTS` - Should include the addresses and private keys of the `feeRecipientAddress`'s you enforce for your orders (per networkId). Your coordinator's signatures will be generated using these private keys.
 -   `SELECTIVE_DELAY_MS` - An optional selective delay between fill request receipt and approval. Adding a delay here can help market makers cancel orders without competing on speed with arbitrageurs.
 -   `EXPIRATION_DURATION_SECONDS` - How long an issued signature should be valid for. This value should be long enough for someone to concievably fill an order, but short enough where off-chain cancellations take effect after some reasonable upper-bound.
 -   `RPC_URL` - The backing Ethereum node to use for JSON RPC queries. Please add your **own** Infura API key if using Infura.
+-   `TAKER_CONTRACT_WHITELIST` - A JSON array of Ethereum contract addresses permitted to fill orders on behalf of others.
 
 6. Build the project
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "start": "node ts/lib/src/server.js",
         "lint": "tslint --project ts --format stylish --exclude ts/src/schemas/**/*",
         "test": "mocha --require source-map-support/register --require make-promises-safe ts/lib/test/**/*_test.js --timeout 6000 --exit",
+        "clean": "shx rm -rf ts/lib",
+        "uninstall": "shx rm -rf node_modules",
         "update_snapshot": "cross-env download --extract --strip 1 --out 0x_ganache_snapshot ${npm_package_config_snapshot_url}",
         "reset_snapshot": "shx rm -rf 0x_ganache_snapshot; yarn update_snapshot"
     },

--- a/ts/src/handlers.ts
+++ b/ts/src/handlers.ts
@@ -148,7 +148,7 @@ export class Handlers {
         signedTransaction: SignedZeroExTransaction,
         coordinatorOrders: Order[],
         takerAssetFillAmounts: BigNumber[],
-        txOrigin?: string,
+        txOrigin: string,
     ): Promise<void> {
         // Find all soft-cancelled orders
         const softCancelledOrderHashes = await orderModel.findSoftCancelledOrdersAsync(coordinatorOrders);
@@ -204,10 +204,6 @@ export class Handlers {
         if (validationErrors.length > 0) {
             throw new ValidationError(validationErrors);
         }
-    }
-    private static _isWhitelistedTakerContract(address: string): boolean {
-        const whitelist = JSON.parse(process.env.TAKER_WHITELIST || '[]');
-        return whitelist.includes(address);
     }
     constructor(networkIdToProvider: NetworkIdToProvider, configs: Configs, broadcastCallback: BroadcastCallback) {
         this._networkIdToProvider = networkIdToProvider;
@@ -540,7 +536,7 @@ export class Handlers {
             signedTransaction,
             coordinatorOrders,
             takerAssetFillAmounts,
-            Handlers._isWhitelistedTakerContract(txOrigin) ? txOrigin : undefined,
+            txOrigin,
         );
 
         const transactionHash = transactionHashUtils.getTransactionHashHex(signedTransaction);
@@ -559,7 +555,7 @@ export class Handlers {
                 signedTransaction,
                 coordinatorOrders,
                 takerAssetFillAmounts,
-                Handlers._isWhitelistedTakerContract(txOrigin) ? txOrigin : undefined,
+                txOrigin,
             );
         }
 

--- a/ts/src/production_configs.ts
+++ b/ts/src/production_configs.ts
@@ -1,6 +1,8 @@
 import * as _ from 'lodash';
 
-export const configs = {
+import { Configs } from './types';
+
+export const configs: Configs = {
     // Network port to listen on
     HTTP_PORT: process.env.COORDINATOR_HTTP_PORT === undefined ? 3000 : _.parseInt(process.env.COORDINATOR_HTTP_PORT),
     // Ethereum RPC url
@@ -22,4 +24,7 @@ export const configs = {
         process.env.EXPIRATION_DURATION_SECONDS === undefined
             ? 90
             : _.parseInt(process.env.EXPIRATION_DURATION_SECONDS), // 1 minute
+    TAKER_CONTRACT_WHITELIST: JSON.parse(process.env.TAKER_CONTRACT_WHITELIST || '[]').map(
+        (address: string): string => address.toLowerCase(),
+    ),
 };

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -10,6 +10,7 @@ export interface Configs {
     NETWORK_ID_TO_CONTRACT_ADDRESSES?: NetworkIdToContractAddresses;
     SELECTIVE_DELAY_MS: number;
     EXPIRATION_DURATION_SECONDS: number;
+    TAKER_CONTRACT_WHITELIST: string[];
 }
 
 export interface RequestTransactionResponse {

--- a/ts/test/tec_test.ts
+++ b/ts/test/tec_test.ts
@@ -25,10 +25,12 @@ import * as HttpStatus from 'http-status-codes';
 import * as _ from 'lodash';
 import 'mocha';
 import * as request from 'supertest';
+import { ConnectionOptions } from 'typeorm';
 import * as WebSocket from 'websocket';
 
 import { getAppAsync } from '../src/app';
 import { assertConfigsAreValid } from '../src/assertions';
+import { defaultOrmConfig } from '../src/default_ormconfig';
 import { TakerAssetFillAmountEntity } from '../src/entities/taker_asset_fill_amount_entity';
 import { TransactionEntity } from '../src/entities/transaction_entity';
 import { GeneralErrorCodes, ValidationErrorCodes } from '../src/errors';
@@ -48,6 +50,11 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 assertConfigsAreValid(configs);
+
+const dbConfigs: ConnectionOptions = {
+    ...defaultOrmConfig,
+    logging: ['error', 'schema', 'warn', 'info', 'log'], // intention: disable 'query'. it's too noisy.
+};
 
 const TESTRPC_PRIVATE_KEYS = _.map(TESTRPC_PRIVATE_KEYS_STRINGS, privateKeyString =>
     ethUtil.toBuffer(privateKeyString),
@@ -197,6 +204,7 @@ describe('Coordinator server', () => {
                     [NETWORK_ID]: provider,
                 },
                 configs,
+                dbConfigs,
             );
         });
         it('should return coordinator configuration', async () => {
@@ -216,6 +224,7 @@ describe('Coordinator server', () => {
                     [NETWORK_ID]: provider,
                 },
                 configs,
+                dbConfigs,
             );
         });
         it('should return 400 Bad Request if request body does not conform to schema', async () => {
@@ -794,6 +803,7 @@ describe('Coordinator server', () => {
                     [NETWORK_ID]: provider,
                 },
                 configWithDelay,
+                dbConfigs,
             );
         });
         it('should abort fill request if cancellation received during selective delay', done => {
@@ -856,6 +866,7 @@ describe('Coordinator server', () => {
                     [NETWORK_ID]: provider,
                 },
                 configs,
+                dbConfigs,
             );
         });
         it('should return 400 Bad Request if request body does not conform to schema', async () => {
@@ -926,6 +937,7 @@ describe('Coordinator server', () => {
                     [NETWORK_ID]: provider,
                 },
                 configs,
+                dbConfigs,
             );
             app.listen(TEST_PORT, () => {
                 utils.log(`Coordinator SERVER API (HTTP) listening on port ${TEST_PORT}`);

--- a/ts/test/test_configs.ts
+++ b/ts/test/test_configs.ts
@@ -23,4 +23,5 @@ export const configs = {
     // Optional selective delay on fill requests
     SELECTIVE_DELAY_MS: 0,
     EXPIRATION_DURATION_SECONDS: 90, // 1 minute
+    TAKER_CONTRACT_WHITELIST: [],
 };

--- a/ts/test/test_configs.ts
+++ b/ts/test/test_configs.ts
@@ -23,5 +23,7 @@ export const configs = {
     // Optional selective delay on fill requests
     SELECTIVE_DELAY_MS: 0,
     EXPIRATION_DURATION_SECONDS: 90, // 1 minute
-    TAKER_CONTRACT_WHITELIST: [],
+    TAKER_CONTRACT_WHITELIST: [
+        '0x78dc5d2d739606d31509c31d654056a45185ecb6', // accounts[4] in ganache snapshot
+    ],
 };


### PR DESCRIPTION
-   [x] Implement ability to query by `txOrigin` rather than just by `takerAddress`, in finding matching orders with amounts left to fill, at https://github.com/0xProject/0x-coordinator-server/blob/fca20c573cd2614e5408db9a90e1b43fe80636cb/ts/src/handlers.ts#L169
-   [x] Document how the server operator can whitelist CFL takers (set environment variable).
-   [x] Parse (and store) whitelist environment variable on server startup, not upon every approval request.
-   [x] After parsing whitelist, convert all addresses to lowercase, and before checking an address against the whitelist, also convert it to lowercase.
-   [ ] Add a test to act as a CFL taker.
