### PR TITLE
Integrate v3 Coordinator with TEC tests

### DIFF
--- a/ts/test/tec_test.ts
+++ b/ts/test/tec_test.ts
@@ -647,7 +647,10 @@ describe('Coordinator server', () => {
             await coordinatorContract
                 .executeTransaction(signedTransaction, txOrigin, signedTransaction.signature, response.body.signatures)
                 .awaitTransactionSuccessAsync(
-                    { from: takerAddress },
+                    {
+                        from: takerAddress,
+                        value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
+                    },
                     { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
                 );
         });
@@ -757,7 +760,10 @@ describe('Coordinator server', () => {
                     response.body.signatures,
                 )
                 .awaitTransactionSuccessAsync(
-                    { from: takerAddress },
+                    {
+                        from: takerAddress,
+                        value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
+                    },
                     { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
                 );
         });
@@ -825,7 +831,10 @@ describe('Coordinator server', () => {
                         response.body.signatures,
                     )
                     .awaitTransactionSuccessAsync(
-                        { from: takerAddress },
+                        {
+                            from: takerAddress,
+                            value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
+                        },
                         { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
                     ),
             ).to.be.fulfilled;
@@ -900,7 +909,10 @@ describe('Coordinator server', () => {
                         response.body.signatures,
                     )
                     .awaitTransactionSuccessAsync(
-                        { from: takerAddress },
+                        {
+                            from: takerAddress,
+                            value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
+                        },
                         { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
                     ),
             ).to.be.fulfilled;
@@ -975,7 +987,10 @@ describe('Coordinator server', () => {
                         response.body.signatures,
                     )
                     .awaitTransactionSuccessAsync(
-                        { from: takerAddress },
+                        {
+                            from: takerAddress,
+                            value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
+                        },
                         { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
                     ),
             ).to.be.fulfilled;

--- a/ts/test/tec_test.ts
+++ b/ts/test/tec_test.ts
@@ -370,14 +370,13 @@ describe('Coordinator server', () => {
             isSoftCancelled = await orderModel.isSoftCancelledAsync(notCoordinatorOrder);
             expect(isSoftCancelled).to.be.false();
 
-            expect(
-                await coordinatorContract
-                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
-                    .awaitTransactionSuccessAsync(
-                        { from: makerAddress },
-                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-                    ),
-            ).to.be.fulfilled;
+            // Execute signed transaction in coordinator contract
+            await coordinatorContract
+                .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                .awaitTransactionSuccessAsync(
+                    { from: makerAddress },
+                    { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                );
         });
         it('should return 200 OK & mark order as cancelled if successfully batch cancelling orders', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync();
@@ -402,14 +401,13 @@ describe('Coordinator server', () => {
             isSoftCancelled = await orderModel.isSoftCancelledAsync(orderTwo);
             expect(isSoftCancelled).to.be.true();
 
-            expect(
-                await coordinatorContract
-                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
-                    .awaitTransactionSuccessAsync(
-                        { from: makerAddress },
-                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-                    ),
-            ).to.be.fulfilled;
+            // Execute signed transaction in coordinator contract
+            await coordinatorContract
+                .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                .awaitTransactionSuccessAsync(
+                    { from: makerAddress },
+                    { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                );
         });
         it('should return 200 OK if request to batchCancel 2 orders each with a different, supported feeRecipientAddress', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync({
@@ -438,14 +436,13 @@ describe('Coordinator server', () => {
             isSoftCancelled = await orderModel.isSoftCancelledAsync(orderTwo);
             expect(isSoftCancelled).to.be.true();
 
-            expect(
-                await coordinatorContract
-                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
-                    .awaitTransactionSuccessAsync(
-                        { from: makerAddress },
-                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-                    ),
-            ).to.be.fulfilled;
+            // Execute signed transaction in coordinator contract
+            await coordinatorContract
+                .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                .awaitTransactionSuccessAsync(
+                    { from: makerAddress },
+                    { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                );
         });
         it('should return 400 and leave order uncancelled if non-maker tried to cancel an order', async () => {
             const order = await orderFactory.newSignedOrderAsync();
@@ -512,14 +509,13 @@ describe('Coordinator server', () => {
             const orderHash = orderHashUtils.getOrderHashHex(order);
             expect(fillResponse.body.validationErrors[0].entities).to.be.deep.equal([orderHash]);
 
-            expect(
-                await coordinatorContract
-                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
-                    .awaitTransactionSuccessAsync(
-                        { from: makerAddress },
-                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-                    ),
-            ).to.be.fulfilled;
+            // Execute signed transaction in coordinator contract
+            await coordinatorContract
+                .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                .awaitTransactionSuccessAsync(
+                    { from: makerAddress },
+                    { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                );
         });
         it('should return 200 OK to order cancellation request & return outstandingFillSignatures', async () => {
             const order = await orderFactory.newSignedOrderAsync();
@@ -568,17 +564,16 @@ describe('Coordinator server', () => {
             expect(response.body.cancellationSignatures.length).to.be.equal(1);
 
             // Execute cancel transaction and validate order was cancelled
-            expect(
-                await coordinatorContract
-                    .executeTransaction(signedCancelTransaction, makerAddress, signedCancelTransaction.signature, [])
-                    .awaitTransactionSuccessAsync(
-                        { from: makerAddress },
-                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-                    ),
-            ).to.be.fulfilled;
-            expect(
-                await exchangeContract.cancelled(orderHashUtils.getOrderHashHex(order)).callAsync()
-            ).to.be.true();
+            await coordinatorContract
+                .executeTransaction(signedCancelTransaction, makerAddress, signedCancelTransaction.signature, [])
+                .awaitTransactionSuccessAsync(
+                    { from: makerAddress },
+                    { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                );
+            const isCancelledOnChain = await exchangeContract
+                .cancelled(orderHashUtils.getOrderHashHex(order))
+                .callAsync();
+            expect(isCancelledOnChain).to.be.true();
         });
         it('should return 400 if request specifies unsupported chainId', async () => {
             const order = await orderFactory.newSignedOrderAsync();
@@ -648,6 +643,7 @@ describe('Coordinator server', () => {
                 (transactionEntityIfExists as TransactionEntity).takerAssetFillAmounts[1].takerAssetFillAmount,
             ).to.be.bignumber.equal(takerAssetFillAmountTwo);
 
+            // Execute signed transaction in coordinator contract
             await coordinatorContract
                 .executeTransaction(signedTransaction, txOrigin, signedTransaction.signature, response.body.signatures)
                 .awaitTransactionSuccessAsync(
@@ -693,6 +689,7 @@ describe('Coordinator server', () => {
                 (transactionEntityIfExists as TransactionEntity).takerAssetFillAmounts[0].takerAssetFillAmount,
             ).to.be.bignumber.equal(takerAssetFillAmount);
 
+            // Execute signed transaction in coordinator contract
             await coordinatorContract
                 .executeTransaction(signedTransaction, txOrigin, signedTransaction.signature, [
                     response.body.signatures[0],
@@ -756,6 +753,8 @@ describe('Coordinator server', () => {
                 t => t.orderHash === orderHashTwo,
             ) as TakerAssetFillAmountEntity;
             expect(takerAssetFillAmountTwo.takerAssetFillAmount).to.be.bignumber.equal(orderTwoTakerAssetFillAmount);
+
+            // Execute signed transaction in coordinator contract
             await coordinatorContract
                 .executeTransaction(
                     signedTransaction,
@@ -826,22 +825,21 @@ describe('Coordinator server', () => {
             ) as TakerAssetFillAmountEntity;
             expect(takerAssetFillAmountTwo.takerAssetFillAmount).to.be.bignumber.equal(orderTwoTakerAssetFillAmount);
 
-            expect(
-                await coordinatorContract
-                    .executeTransaction(
-                        signedTransaction,
-                        takerAddress,
-                        signedTransaction.signature,
-                        response.body.signatures,
-                    )
-                    .awaitTransactionSuccessAsync(
-                        {
-                            from: takerAddress,
-                            value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
-                        },
-                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-                    ),
-            ).to.be.fulfilled;
+            // Execute signed transaction in coordinator contract
+            await coordinatorContract
+                .executeTransaction(
+                    signedTransaction,
+                    takerAddress,
+                    signedTransaction.signature,
+                    response.body.signatures,
+                )
+                .awaitTransactionSuccessAsync(
+                    {
+                        from: takerAddress,
+                        value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
+                    },
+                    { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                );
         });
         it('should return 200 OK if request to marketBuy uncancelled orders', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync();
@@ -904,22 +902,21 @@ describe('Coordinator server', () => {
             );
             expect(expectedOrderTwoMakerAssetFillAmount).to.be.bignumber.equal(orderTwoMakerAssetFillAmount);
 
-            expect(
-                await coordinatorContract
-                    .executeTransaction(
-                        signedTransaction,
-                        takerAddress,
-                        signedTransaction.signature,
-                        response.body.signatures,
-                    )
-                    .awaitTransactionSuccessAsync(
-                        {
-                            from: takerAddress,
-                            value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
-                        },
-                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-                    ),
-            ).to.be.fulfilled;
+            // Execute signed transaction in coordinator contract
+            await coordinatorContract
+                .executeTransaction(
+                    signedTransaction,
+                    takerAddress,
+                    signedTransaction.signature,
+                    response.body.signatures,
+                )
+                .awaitTransactionSuccessAsync(
+                    {
+                        from: takerAddress,
+                        value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
+                    },
+                    { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                );
         });
         it('should return 200 OK if request to marketBuyFillOrKill uncancelled orders', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync();
@@ -982,22 +979,21 @@ describe('Coordinator server', () => {
             );
             expect(expectedOrderTwoMakerAssetFillAmount).to.be.bignumber.equal(orderTwoMakerAssetFillAmount);
 
-            expect(
-                await coordinatorContract
-                    .executeTransaction(
-                        signedTransaction,
-                        takerAddress,
-                        signedTransaction.signature,
-                        response.body.signatures,
-                    )
-                    .awaitTransactionSuccessAsync(
-                        {
-                            from: takerAddress,
-                            value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
-                        },
-                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-                    ),
-            ).to.be.fulfilled;
+            // Execute signed transaction in coordinator contract
+            await coordinatorContract
+                .executeTransaction(
+                    signedTransaction,
+                    takerAddress,
+                    signedTransaction.signature,
+                    response.body.signatures,
+                )
+                .awaitTransactionSuccessAsync(
+                    {
+                        from: takerAddress,
+                        value: DEFAULT_PROTOCOL_FEE_MULTIPLIER.times(defaultTransactionParams.gasPrice).times(2),
+                    },
+                    { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                );
         });
         it('should return 400 TRANSACTION_ALREADY_USED if request same 0x transaction multiple times', async () => {
             const order = await orderFactory.newSignedOrderAsync();

--- a/ts/test/tec_test.ts
+++ b/ts/test/tec_test.ts
@@ -1,6 +1,5 @@
-import { CoordinatorContract, ERC20TokenContract } from '@0x/abi-gen-wrappers';
-import { ContractAddresses, getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
-import { ContractWrappers } from '@0x/contract-wrappers';
+import { CoordinatorContract, ERC20TokenContract, ExchangeContract } from '@0x/abi-gen-wrappers';
+import { ContractAddresses } from '@0x/contract-addresses';
 import { IAssetDataContract } from '@0x/contracts-asset-proxy';
 import { DummyERC20TokenContract } from '@0x/contracts-erc20';
 import {
@@ -15,7 +14,7 @@ import { runMigrationsOnceAsync } from '@0x/migrations';
 import { orderCalculationUtils, SignatureType } from '@0x/order-utils';
 import { Web3ProviderEngine } from '@0x/subproviders';
 import { SignedZeroExTransaction, ZeroExTransaction } from '@0x/types';
-import { BigNumber, decodeBytesAsRevertError, fetchAsync } from '@0x/utils';
+import { BigNumber, fetchAsync } from '@0x/utils';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
@@ -55,7 +54,11 @@ const TESTRPC_PRIVATE_KEYS = _.map(TESTRPC_PRIVATE_KEYS_STRINGS, privateKeyStrin
 );
 const UNLIMITED_ALLOWANCE = new BigNumber(2).pow(256).minus(1);
 const DEFAULT_PROTOCOL_FEE_MULTIPLIER = new BigNumber(150000);
-
+const TX_DEFAULTS = {
+    gasPrice: new BigNumber(1),
+    gas: testConstants.MAX_EXECUTE_TRANSACTION_GAS,
+    value: DEFAULT_PROTOCOL_FEE_MULTIPLIER,
+};
 let app: http.Server;
 
 let web3Wrapper: Web3Wrapper;
@@ -71,7 +74,9 @@ let provider: Web3ProviderEngine;
 let accounts: string[];
 let contractAddresses: ContractAddresses;
 let blockchainLifecycle: BlockchainLifecycle;
-let contractWrappers: ContractWrappers;
+
+let coordinatorContract: CoordinatorContract;
+let exchangeContract: ExchangeContract;
 
 // Websocket tests only
 const TEST_PORT = 8361;
@@ -108,17 +113,15 @@ describe('Coordinator server', () => {
         await blockchainLifecycle.startAsync();
         accounts = await web3Wrapper.getAvailableAddressesAsync();
         [owner, makerAddress, takerAddress, feeRecipientAddress] = _.slice(accounts, 0, 6);
-        await runMigrationsOnceAsync(provider, { from: owner });
+        contractAddresses = await runMigrationsOnceAsync(provider, { from: owner });
 
-        contractAddresses = getContractAddressesForChainOrThrow(CHAIN_ID);
         const settings: NetworkSpecificSettings = configs.CHAIN_ID_TO_SETTINGS[CHAIN_ID];
         if (feeRecipientAddress !== settings.FEE_RECIPIENTS[0].ADDRESS) {
             throw new Error(`Expected settings.FEE_RECIPEINTS[0].ADDRESS to be ${feeRecipientAddress}`);
         }
 
-        contractWrappers = new ContractWrappers(provider, {
-            chainId: CHAIN_ID,
-        });
+        exchangeContract = new ExchangeContract(contractAddresses.exchange, provider);
+        coordinatorContract = new CoordinatorContract(contractAddresses.coordinator, provider, TX_DEFAULTS);
 
         const defaultOrderParams = {
             ...testConstants.STATIC_ORDER_PARAMS,
@@ -135,7 +138,7 @@ describe('Coordinator server', () => {
         const makerPrivateKey = TESTRPC_PRIVATE_KEYS[accounts.indexOf(makerAddress)];
         orderFactory = new OrderFactory(makerPrivateKey, defaultOrderParams);
         const testOrder = await orderFactory.newSignedOrderAsync();
-        const fillTestOrderCalldata = contractWrappers.exchange
+        const fillTestOrderCalldata = exchangeContract
             .fillOrder(testOrder, new BigNumber(5), testOrder.signature)
             .getABIEncodedTransactionData();
 
@@ -165,62 +168,62 @@ describe('Coordinator server', () => {
         const takerBalance = testConstants.STATIC_ORDER_PARAMS.takerAssetAmount.times(5);
         const takerAllowance = UNLIMITED_ALLOWANCE;
 
-        await makerTokenContract.setBalance(makerAddress, makerBalance).awaitTransactionSuccessAsync(
-            {
-                from: owner,
-            },
-            { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-        );
+        await makerTokenContract
+            .setBalance(makerAddress, makerBalance)
+            .awaitTransactionSuccessAsync(
+                { from: owner },
+                { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+            );
 
-        await makerTokenContract.approve(contractAddresses.erc20Proxy, makerAllowance).awaitTransactionSuccessAsync(
-            {
-                from: makerAddress,
-            },
-            { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-        );
+        await makerTokenContract
+            .approve(contractAddresses.erc20Proxy, makerAllowance)
+            .awaitTransactionSuccessAsync(
+                { from: makerAddress },
+                { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+            );
         const zrxToken = new ERC20TokenContract(contractAddresses.zrxToken, provider);
 
-        await zrxToken.transfer(makerAddress, makerBalance).awaitTransactionSuccessAsync(
-            {
-                from: owner,
-            },
-            { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-        );
+        await zrxToken
+            .transfer(makerAddress, makerBalance)
+            .awaitTransactionSuccessAsync(
+                { from: owner },
+                { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+            );
 
-        await zrxToken.approve(contractAddresses.erc20Proxy, UNLIMITED_ALLOWANCE).awaitTransactionSuccessAsync(
-            {
-                from: makerAddress,
-            },
-            { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-        );
+        await zrxToken
+            .approve(contractAddresses.erc20Proxy, UNLIMITED_ALLOWANCE)
+            .awaitTransactionSuccessAsync(
+                { from: makerAddress },
+                { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+            );
 
-        await takerTokenContract.setBalance(takerAddress, takerBalance).awaitTransactionSuccessAsync(
-            {
-                from: owner,
-            },
-            { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-        );
+        await takerTokenContract
+            .setBalance(takerAddress, takerBalance)
+            .awaitTransactionSuccessAsync(
+                { from: owner },
+                { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+            );
 
-        await takerTokenContract.approve(contractAddresses.erc20Proxy, takerAllowance).awaitTransactionSuccessAsync(
-            {
-                from: takerAddress,
-            },
-            { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-        );
+        await takerTokenContract
+            .approve(contractAddresses.erc20Proxy, takerAllowance)
+            .awaitTransactionSuccessAsync(
+                { from: takerAddress },
+                { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+            );
 
-        await zrxToken.transfer(takerAddress, takerBalance).awaitTransactionSuccessAsync(
-            {
-                from: owner,
-            },
-            { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-        );
+        await zrxToken
+            .transfer(takerAddress, takerBalance)
+            .awaitTransactionSuccessAsync(
+                { from: owner },
+                { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+            );
 
-        await zrxToken.approve(contractAddresses.erc20Proxy, UNLIMITED_ALLOWANCE).awaitTransactionSuccessAsync(
-            {
-                from: takerAddress,
-            },
-            { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
-        );
+        await zrxToken
+            .approve(contractAddresses.erc20Proxy, UNLIMITED_ALLOWANCE)
+            .awaitTransactionSuccessAsync(
+                { from: takerAddress },
+                { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+            );
     });
     afterEach(async () => {
         await blockchainLifecycle.revertAsync();
@@ -290,7 +293,7 @@ describe('Coordinator server', () => {
                 feeRecipientAddress: NOT_COORDINATOR_FEE_RECIPIENT_ADDRESS,
             });
             const takerAssetFillAmount = order.takerAssetAmount.div(2);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data }, takerAddress, CHAIN_ID);
@@ -326,7 +329,7 @@ describe('Coordinator server', () => {
         });
         it('should return 400 if batch cancellation transaction not signed by order maker', async () => {
             const order = await orderFactory.newSignedOrderAsync();
-            const data = contractWrappers.exchange.batchCancelOrders([order]).getABIEncodedTransactionData();
+            const data = exchangeContract.batchCancelOrders([order]).getABIEncodedTransactionData();
             const notMakerAddress = takerAddress;
             const signedTransaction = await createSignedTransactionAsync({ data }, notMakerAddress, CHAIN_ID);
             const body = {
@@ -345,7 +348,7 @@ describe('Coordinator server', () => {
             const notCoordinatorOrder = await orderFactory.newSignedOrderAsync({
                 feeRecipientAddress: NOT_COORDINATOR_FEE_RECIPIENT_ADDRESS,
             });
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .batchCancelOrders([coordinatorOrder, notCoordinatorOrder])
                 .getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data }, makerAddress, CHAIN_ID);
@@ -366,13 +369,20 @@ describe('Coordinator server', () => {
             expect(isSoftCancelled).to.be.true();
             isSoftCancelled = await orderModel.isSoftCancelledAsync(notCoordinatorOrder);
             expect(isSoftCancelled).to.be.false();
+
+            expect(
+                await coordinatorContract
+                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                    .awaitTransactionSuccessAsync(
+                        { from: makerAddress },
+                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                    ),
+            ).to.be.fulfilled;
         });
         it('should return 200 OK & mark order as cancelled if successfully batch cancelling orders', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync();
             const orderTwo = await orderFactory.newSignedOrderAsync();
-            const data = contractWrappers.exchange
-                .batchCancelOrders([orderOne, orderTwo])
-                .getABIEncodedTransactionData();
+            const data = exchangeContract.batchCancelOrders([orderOne, orderTwo]).getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data }, makerAddress, CHAIN_ID);
             const body = {
                 signedTransaction,
@@ -391,6 +401,15 @@ describe('Coordinator server', () => {
             expect(isSoftCancelled).to.be.true();
             isSoftCancelled = await orderModel.isSoftCancelledAsync(orderTwo);
             expect(isSoftCancelled).to.be.true();
+
+            expect(
+                await coordinatorContract
+                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                    .awaitTransactionSuccessAsync(
+                        { from: makerAddress },
+                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                    ),
+            ).to.be.fulfilled;
         });
         it('should return 200 OK if request to batchCancel 2 orders each with a different, supported feeRecipientAddress', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync({
@@ -399,9 +418,7 @@ describe('Coordinator server', () => {
             const orderTwo = await orderFactory.newSignedOrderAsync({
                 feeRecipientAddress: FEE_RECIPIENT_ADDRESS_TWO,
             });
-            const data = contractWrappers.exchange
-                .batchCancelOrders([orderOne, orderTwo])
-                .getABIEncodedTransactionData();
+            const data = exchangeContract.batchCancelOrders([orderOne, orderTwo]).getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data }, makerAddress, CHAIN_ID);
             const body = {
                 signedTransaction,
@@ -420,10 +437,19 @@ describe('Coordinator server', () => {
             expect(isSoftCancelled).to.be.true();
             isSoftCancelled = await orderModel.isSoftCancelledAsync(orderTwo);
             expect(isSoftCancelled).to.be.true();
+
+            expect(
+                await coordinatorContract
+                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                    .awaitTransactionSuccessAsync(
+                        { from: makerAddress },
+                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                    ),
+            ).to.be.fulfilled;
         });
         it('should return 400 and leave order uncancelled if non-maker tried to cancel an order', async () => {
             const order = await orderFactory.newSignedOrderAsync();
-            const data = contractWrappers.exchange.cancelOrder(order).getABIEncodedTransactionData();
+            const data = exchangeContract.cancelOrder(order).getABIEncodedTransactionData();
             const notMakerAddress = owner;
             const signedTransaction = await createSignedTransactionAsync({ data }, notMakerAddress, CHAIN_ID);
             const body = {
@@ -443,7 +469,7 @@ describe('Coordinator server', () => {
         });
         it('should return 200 OK & mark order as cancelled if successfully cancelling an order', async () => {
             const order = await orderFactory.newSignedOrderAsync();
-            const cancelData = contractWrappers.exchange.cancelOrder(order).getABIEncodedTransactionData();
+            const cancelData = exchangeContract.cancelOrder(order).getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data: cancelData }, makerAddress, CHAIN_ID);
             const body = {
                 signedTransaction,
@@ -463,7 +489,7 @@ describe('Coordinator server', () => {
 
             // Check that someone trying to fill the order, can't
             const takerAssetFillAmount = order.takerAssetAmount.div(2);
-            const fillData = contractWrappers.exchange
+            const fillData = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const signedFillTransaction = await createSignedTransactionAsync(
@@ -485,13 +511,22 @@ describe('Coordinator server', () => {
             );
             const orderHash = orderHashUtils.getOrderHashHex(order);
             expect(fillResponse.body.validationErrors[0].entities).to.be.deep.equal([orderHash]);
+
+            expect(
+                await coordinatorContract
+                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                    .awaitTransactionSuccessAsync(
+                        { from: makerAddress },
+                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                    ),
+            ).to.be.fulfilled;
         });
         it('should return 200 OK to order cancellation request & return outstandingFillSignatures', async () => {
             const order = await orderFactory.newSignedOrderAsync();
 
             // Request to fill order
             const takerAssetFillAmount = order.takerAssetAmount.div(2);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data }, takerAddress, CHAIN_ID);
@@ -505,7 +540,7 @@ describe('Coordinator server', () => {
             expect(fillResponse.status).to.be.equal(HttpStatus.OK);
 
             // Once fill request granted, request to cancel order
-            const cancelData = contractWrappers.exchange.cancelOrder(order).getABIEncodedTransactionData();
+            const cancelData = exchangeContract.cancelOrder(order).getABIEncodedTransactionData();
             const signedCancelTransaction = await createSignedTransactionAsync(
                 { data: cancelData },
                 makerAddress,
@@ -531,11 +566,20 @@ describe('Coordinator server', () => {
                 takerAssetFillAmount,
             );
             expect(response.body.cancellationSignatures.length).to.be.equal(1);
+
+            expect(
+                await coordinatorContract
+                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                    .awaitTransactionSuccessAsync(
+                        { from: makerAddress },
+                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                    ),
+            ).to.be.fulfilled;
         });
         it('should return 400 if request specifies unsupported chainId', async () => {
             const order = await orderFactory.newSignedOrderAsync();
             const takerAssetFillAmount = order.takerAssetAmount.div(2);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data }, takerAddress, CHAIN_ID);
@@ -552,7 +596,7 @@ describe('Coordinator server', () => {
             expect(response.body.validationErrors[0].code).to.be.equal(ValidationErrorCodes.UnsupportedOption);
             expect(response.body.validationErrors[0].field).to.be.equal('chainId');
         });
-        it.only('should return 200 OK if request to batchFill 2 orders each with a different, supported feeRecipientAddress', async () => {
+        it('should return 200 OK if request to batchFill 2 orders each with a different, supported feeRecipientAddress', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync({
                 feeRecipientAddress: FEE_RECIPIENT_ADDRESS_ONE,
             });
@@ -561,7 +605,7 @@ describe('Coordinator server', () => {
             });
             const takerAssetFillAmountOne = orderOne.takerAssetAmount;
             const takerAssetFillAmountTwo = orderTwo.takerAssetAmount;
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .batchFillOrders(
                     [orderOne, orderTwo],
                     [takerAssetFillAmountOne, takerAssetFillAmountTwo],
@@ -600,27 +644,17 @@ describe('Coordinator server', () => {
                 (transactionEntityIfExists as TransactionEntity).takerAssetFillAmounts[1].takerAssetFillAmount,
             ).to.be.bignumber.equal(takerAssetFillAmountTwo);
 
-            const coordinatorContract = new CoordinatorContract(contractAddresses.coordinator, provider);
-            try {
-                await coordinatorContract
+            await coordinatorContract
                 .executeTransaction(signedTransaction, txOrigin, signedTransaction.signature, response.body.signatures)
                 .awaitTransactionSuccessAsync(
-                    {
-                        from: takerAddress,
-                        gasPrice: defaultTransactionParams.gasPrice,
-                        gas: testConstants.MAX_EXECUTE_TRANSACTION_GAS,
-                        value: DEFAULT_PROTOCOL_FEE_MULTIPLIER,
-                    },
+                    { from: takerAddress },
                     { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
                 );
-            } catch (e) {
-                console.log(decodeBytesAsRevertError(e.values.errorData));
-            }
         });
         it('should return 200 OK if request to fill uncancelled order', async () => {
             const order = await orderFactory.newSignedOrderAsync();
             const takerAssetFillAmount = order.takerAssetAmount.div(2);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data }, takerAddress, CHAIN_ID);
@@ -652,19 +686,12 @@ describe('Coordinator server', () => {
                 (transactionEntityIfExists as TransactionEntity).takerAssetFillAmounts[0].takerAssetFillAmount,
             ).to.be.bignumber.equal(takerAssetFillAmount);
 
-            const coordinatorContract = new CoordinatorContract(contractAddresses.coordinator, provider);
-
             await coordinatorContract
                 .executeTransaction(signedTransaction, txOrigin, signedTransaction.signature, [
                     response.body.signatures[0],
                 ])
                 .awaitTransactionSuccessAsync(
-                    {
-                        from: takerAddress,
-                        gasPrice: defaultTransactionParams.gasPrice,
-                        gas: testConstants.MAX_EXECUTE_TRANSACTION_GAS,
-                        value: DEFAULT_PROTOCOL_FEE_MULTIPLIER,
-                    },
+                    { from: takerAddress },
                     { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
                 );
         });
@@ -675,7 +702,7 @@ describe('Coordinator server', () => {
             const orderOneTakerAssetFillAmount = orderOne.takerAssetAmount;
             const orderTwoTakerAssetFillAmount = orderTwo.takerAssetAmount.div(2);
             const takerAssetFillAmount = orderOneTakerAssetFillAmount.plus(orderTwoTakerAssetFillAmount);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .marketSellOrdersFillOrKill([orderOne, orderTwo], takerAssetFillAmount, [
                     orderOne.signature,
                     orderTwo.signature,
@@ -722,6 +749,17 @@ describe('Coordinator server', () => {
                 t => t.orderHash === orderHashTwo,
             ) as TakerAssetFillAmountEntity;
             expect(takerAssetFillAmountTwo.takerAssetFillAmount).to.be.bignumber.equal(orderTwoTakerAssetFillAmount);
+            await coordinatorContract
+                .executeTransaction(
+                    signedTransaction,
+                    takerAddress,
+                    signedTransaction.signature,
+                    response.body.signatures,
+                )
+                .awaitTransactionSuccessAsync(
+                    { from: takerAddress },
+                    { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                );
         });
         it('should return 200 OK if request to marketSellOrdersNoThrow uncancelled orders', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync();
@@ -730,7 +768,7 @@ describe('Coordinator server', () => {
             const orderOneTakerAssetFillAmount = orderOne.takerAssetAmount;
             const orderTwoTakerAssetFillAmount = orderTwo.takerAssetAmount.div(2);
             const takerAssetFillAmount = orderOneTakerAssetFillAmount.plus(orderTwoTakerAssetFillAmount);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .marketSellOrdersNoThrow([orderOne, orderTwo], takerAssetFillAmount, [
                     orderOne.signature,
                     orderTwo.signature,
@@ -777,6 +815,20 @@ describe('Coordinator server', () => {
                 t => t.orderHash === orderHashTwo,
             ) as TakerAssetFillAmountEntity;
             expect(takerAssetFillAmountTwo.takerAssetFillAmount).to.be.bignumber.equal(orderTwoTakerAssetFillAmount);
+
+            expect(
+                await coordinatorContract
+                    .executeTransaction(
+                        signedTransaction,
+                        takerAddress,
+                        signedTransaction.signature,
+                        response.body.signatures,
+                    )
+                    .awaitTransactionSuccessAsync(
+                        { from: takerAddress },
+                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                    ),
+            ).to.be.fulfilled;
         });
         it('should return 200 OK if request to marketBuy uncancelled orders', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync();
@@ -785,7 +837,7 @@ describe('Coordinator server', () => {
             const orderOneMakerAssetFillAmount = orderOne.makerAssetAmount;
             const orderTwoMakerAssetFillAmount = orderTwo.makerAssetAmount.div(2);
             const makerAssetFillAmount = orderOneMakerAssetFillAmount.plus(orderTwoMakerAssetFillAmount);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .marketBuyOrdersNoThrow([orderOne, orderTwo], makerAssetFillAmount, [
                     orderOne.signature,
                     orderTwo.signature,
@@ -838,6 +890,20 @@ describe('Coordinator server', () => {
                 takerAssetFillAmountTwo.takerAssetFillAmount,
             );
             expect(expectedOrderTwoMakerAssetFillAmount).to.be.bignumber.equal(orderTwoMakerAssetFillAmount);
+
+            expect(
+                await coordinatorContract
+                    .executeTransaction(
+                        signedTransaction,
+                        takerAddress,
+                        signedTransaction.signature,
+                        response.body.signatures,
+                    )
+                    .awaitTransactionSuccessAsync(
+                        { from: takerAddress },
+                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                    ),
+            ).to.be.fulfilled;
         });
         it('should return 200 OK if request to marketBuyFillOrKill uncancelled orders', async () => {
             const orderOne = await orderFactory.newSignedOrderAsync();
@@ -846,7 +912,7 @@ describe('Coordinator server', () => {
             const orderOneMakerAssetFillAmount = orderOne.makerAssetAmount;
             const orderTwoMakerAssetFillAmount = orderTwo.makerAssetAmount.div(2);
             const makerAssetFillAmount = orderOneMakerAssetFillAmount.plus(orderTwoMakerAssetFillAmount);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .marketBuyOrdersFillOrKill([orderOne, orderTwo], makerAssetFillAmount, [
                     orderOne.signature,
                     orderTwo.signature,
@@ -899,11 +965,25 @@ describe('Coordinator server', () => {
                 takerAssetFillAmountTwo.takerAssetFillAmount,
             );
             expect(expectedOrderTwoMakerAssetFillAmount).to.be.bignumber.equal(orderTwoMakerAssetFillAmount);
+
+            expect(
+                await coordinatorContract
+                    .executeTransaction(
+                        signedTransaction,
+                        takerAddress,
+                        signedTransaction.signature,
+                        response.body.signatures,
+                    )
+                    .awaitTransactionSuccessAsync(
+                        { from: takerAddress },
+                        { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
+                    ),
+            ).to.be.fulfilled;
         });
         it('should return 400 TRANSACTION_ALREADY_USED if request same 0x transaction multiple times', async () => {
             const order = await orderFactory.newSignedOrderAsync();
             const takerAssetFillAmount = order.takerAssetAmount; // Full amount
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data }, takerAddress, CHAIN_ID);
@@ -930,7 +1010,7 @@ describe('Coordinator server', () => {
         it('should return 400 FILL_REQUESTS_EXCEEDED_TAKER_ASSET_AMOUNT if request to fill an order multiple times fully', async () => {
             const order = await orderFactory.newSignedOrderAsync();
             const takerAssetFillAmount = order.takerAssetAmount; // Full amount
-            const dataOne = contractWrappers.exchange
+            const dataOne = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const signedTransactionOne = await createSignedTransactionAsync({ data: dataOne }, takerAddress, CHAIN_ID);
@@ -947,7 +1027,7 @@ describe('Coordinator server', () => {
             const currTimestamp = utils.getCurrentTimestampSeconds();
             expect(response.body.expirationTimeSeconds).to.be.greaterThan(currTimestamp);
 
-            const dataTwo = contractWrappers.exchange
+            const dataTwo = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const signedTransactionTwo = await createSignedTransactionAsync({ data: dataTwo }, takerAddress, CHAIN_ID);
@@ -969,7 +1049,7 @@ describe('Coordinator server', () => {
         it('should return 400 if transaction `expirationTimeSeconds` is too high', async () => {
             const order = await orderFactory.newSignedOrderAsync();
             const takerAssetFillAmount = order.takerAssetAmount.div(2);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const maxApproximateValidExpirationTimeSeconds =
@@ -1018,7 +1098,7 @@ describe('Coordinator server', () => {
                 // Do fill request async
                 const order = await orderFactory.newSignedOrderAsync();
                 const takerAssetFillAmount = order.takerAssetAmount.div(2);
-                const data = contractWrappers.exchange
+                const data = exchangeContract
                     .fillOrder(order, takerAssetFillAmount, order.signature)
                     .getABIEncodedTransactionData();
                 const signedFillTransaction = await createSignedTransactionAsync({ data }, takerAddress, CHAIN_ID);
@@ -1044,7 +1124,7 @@ describe('Coordinator server', () => {
                 await utils.sleepAsync(100);
 
                 // Do cancellation request
-                const cancelData = contractWrappers.exchange.cancelOrder(order).getABIEncodedTransactionData();
+                const cancelData = exchangeContract.cancelOrder(order).getABIEncodedTransactionData();
                 const signedCancelTransaction = await createSignedTransactionAsync(
                     { data: cancelData },
                     makerAddress,
@@ -1105,7 +1185,7 @@ describe('Coordinator server', () => {
             const orderTwo = await orderFactory.newSignedOrderAsync();
             const orderThree = await orderFactory.newSignedOrderAsync();
             const orderFour = await orderFactory.newSignedOrderAsync();
-            const cancelData = contractWrappers.exchange
+            const cancelData = exchangeContract
                 .batchCancelOrders([orderOne, orderTwo, orderThree])
                 .getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data: cancelData }, makerAddress, CHAIN_ID);
@@ -1165,7 +1245,7 @@ describe('Coordinator server', () => {
             // Send fill request
             const order = await orderFactory.newSignedOrderAsync();
             const takerAssetFillAmount = order.takerAssetAmount.div(2);
-            const data = contractWrappers.exchange
+            const data = exchangeContract
                 .fillOrder(order, takerAssetFillAmount, order.signature)
                 .getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data }, takerAddress, CHAIN_ID);
@@ -1209,7 +1289,7 @@ describe('Coordinator server', () => {
 
             // Send fill request
             const order = await orderFactory.newSignedOrderAsync();
-            const cancelData = contractWrappers.exchange.cancelOrder(order).getABIEncodedTransactionData();
+            const cancelData = exchangeContract.cancelOrder(order).getABIEncodedTransactionData();
             const signedTransaction = await createSignedTransactionAsync({ data: cancelData }, makerAddress, CHAIN_ID);
             const body = {
                 signedTransaction,

--- a/ts/test/tec_test.ts
+++ b/ts/test/tec_test.ts
@@ -567,14 +567,18 @@ describe('Coordinator server', () => {
             );
             expect(response.body.cancellationSignatures.length).to.be.equal(1);
 
+            // Execute cancel transaction and validate order was cancelled
             expect(
                 await coordinatorContract
-                    .executeTransaction(signedTransaction, makerAddress, signedTransaction.signature, [])
+                    .executeTransaction(signedCancelTransaction, makerAddress, signedCancelTransaction.signature, [])
                     .awaitTransactionSuccessAsync(
                         { from: makerAddress },
                         { pollingIntervalMs: testConstants.AWAIT_TRANSACTION_MINED_MS },
                     ),
             ).to.be.fulfilled;
+            expect(
+                await exchangeContract.cancelled(orderHashUtils.getOrderHashHex(order)).callAsync()
+            ).to.be.true();
         });
         it('should return 400 if request specifies unsupported chainId', async () => {
             const order = await orderFactory.newSignedOrderAsync();


### PR DESCRIPTION
The migrations in the monorepo have been updated to and deploy v3 of the coordinator contracts. This PR adds integration tests with the contracts to existing TEC tests. This provides more robust validation against the coordinator server.